### PR TITLE
Fix createInstance cloning issue.

### DIFF
--- a/ometa-base.js
+++ b/ometa-base.js
@@ -504,8 +504,8 @@ OMeta = {
     var m = objectThatDelegatesTo(this)
     m.initialize()
     m.matchAll = function(listyObj, aRule) {
-      m.input = listyObj.toOMInputStream()
-      return m._apply(aRule)
+      this.input = listyObj.toOMInputStream()
+      return this._apply(aRule)
     }
     return m
   }


### PR DESCRIPTION
It would be great if you could pull this small change, it fixes an issue when cloning the the object returned by createInstance that any calls to matchAll on the cloned object actually run on the original object (which is unintuitive and I assume unintended).

Thanks
