### PR TITLE
Fix parsing of \xHH and \uHHHH

### DIFF
--- a/bs-js-compiler.txt
+++ b/bs-js-compiler.txt
@@ -15,7 +15,7 @@ ometa BSJSParser {
                      '"' | "'" | '\\'
                    | 'n' | 'r' | 't'
                    | 'b' | 'f'
-                   | <'u' digit digit digit digit> | <'x' digit digit>
+                   | <'u' char char char char> | <'x' char char>
                    | char ):c                                                        -> unescape('\\' + c),
   str          = seq('"""')  (escapeChar | ~seq('"""') char)*:cs seq('"""')          -> [#string, cs.join('')]
                | '\'' (escapeChar | ~'\'' char)*:cs '\''                             -> [#string, cs.join('')]

--- a/bs-js-compiler.txt
+++ b/bs-js-compiler.txt
@@ -11,7 +11,12 @@ ometa BSJSParser {
                | hexDigit,
   number       = ``0x'' hexLit:n                                                     -> [#number, n]
                | <digit+ ('.' digit+)?>:f                                            -> [#number, parseFloat(f)],
-  escapeChar   = '\\' char:c                                                         -> unescape('\\' + c),
+  escapeChar   = '\\' (
+                     '"' | "'" | '\\'
+                   | 'n' | 'r' | 't'
+                   | 'b' | 'f'
+                   | <'u' digit digit digit digit> | <'x' digit digit>
+                   | char ):c                                                        -> unescape('\\' + c),
   str          = seq('"""')  (escapeChar | ~seq('"""') char)*:cs seq('"""')          -> [#string, cs.join('')]
                | '\'' (escapeChar | ~'\'' char)*:cs '\''                             -> [#string, cs.join('')]
                | '"'  (escapeChar | ~'"'  char)*:cs '"'                              -> [#string, cs.join('')]


### PR DESCRIPTION
After 23e66f4dd6e374d9d9a9abba25027ec247cdad5e Ometa/JS serialize escaped chars, but still can't parse it back.
