### PR TITLE
Fix .match for an instance from .createInstance

### DIFF
--- a/ometa-base.js
+++ b/ometa-base.js
@@ -496,6 +496,9 @@ OMeta = {
       this.input = listyObj.toOMInputStream()
       return this._apply(aRule)
     }
+    m.match = function(obj, aRule) {
+      return this.matchAll([obj], aRule)
+    }
     return m
   }
 }


### PR DESCRIPTION
Currently when running a .match on a created instance it creates a new instance and runs initialize on it, which does not seem like the intended behaviour.
