### PR TITLE
Minor correction to the tutorial.

### DIFF
--- a/OMeta_Tutorial.txt
+++ b/OMeta_Tutorial.txt
@@ -37,7 +37,7 @@ ometa Calc {
   expr     = addExpr
 }
 
-Calc.matchAll('6**(4+3)', 'expr')
+Calc.matchAll('6*(4+3)', 'expr')
 
 
 


### PR DESCRIPTION
The example input string for Calc had exponentiation instead of
multiplication, which caused the interpreter to not recognize the
whole string and return the initially confusing answer of 6.

This patch makes the string the same as all the others, and gives
the result 42.
